### PR TITLE
CHERRYPICK: "certagent: use kubeconfig to create client for k8s api"

### DIFF
--- a/pkg/certagent/agent_test.go
+++ b/pkg/certagent/agent_test.go
@@ -14,11 +14,10 @@ import (
 
 var (
 	cConfig = CSRConfig{
-		DNSNames:      []string{"localhost"},
-		IPAddresses:   []net.IP{net.ParseIP("127.0.0.1")},
-		OrgName:       "system:etcd-peers",
-		CommonName:    "system:etcd-peer:test",
-		SignerAddress: "http://127.0.0.1:6443",
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		OrgName:     "system:etcd-peers",
+		CommonName:  "system:etcd-peer:test",
 	}
 )
 


### PR DESCRIPTION
This  PR cherry-picks b9c062dadea310b50b088bc1179a0687838e898f into 4.0. The initial pin was based on https://github.com/openshift/installer/blob/c91cdbc819851fb9f813ec0b3e3b76ed86ae43a3/pkg/asset/ignition/bootstrap/bootstrap.go#L34

Which was trailing 

https://github.com/openshift/machine-config-operator/blob/9fbdaffd81a7a44ee3830929a7a10296b9fa8b06/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml#L28