### PR TITLE
cherry-pick: *: add --max-retry flag to kube-client-agent

### DIFF
--- a/cmd/kube-client-agent/request.go
+++ b/cmd/kube-client-agent/request.go
@@ -26,6 +26,7 @@ var (
 		ipAddresses string
 		assetsDir   string
 		kubeconfig  string
+		maxRetry    int
 	}
 )
 
@@ -37,6 +38,7 @@ func init() {
 	requestCmd.PersistentFlags().StringVar(&requestOpts.ipAddresses, "ipaddrs", "", "Comma separated IP addresses of the node to be provided for the X509 certificate")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.assetsDir, "assetsdir", "", "Directory location for the agent where it stores signed certs")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to connect to apiserver. If \"\", InClusterConfig is used which uses the service account kubernetes gives to pods.")
+	requestCmd.PersistentFlags().IntVar(&requestOpts.maxRetry, "max-retry", 0, "If value is greater than 0 wait 10 seconds for success and retry N times.")
 }
 
 func validateRequestOpts(cmd *cobra.Command, args []string) error {
@@ -81,6 +83,7 @@ func runCmdRequest(cmd *cobra.Command, args []string) error {
 		DNSNames:    strings.Split(requestOpts.dnsNames, ","),
 		IPAddresses: ips,
 		AssetsDir:   requestOpts.assetsDir,
+		MaxRetry:    requestOpts.maxRetry,
 	}
 	a, err := agent.NewAgent(config, requestOpts.kubeconfig)
 	if err != nil {

--- a/pkg/certagent/agent.go
+++ b/pkg/certagent/agent.go
@@ -34,6 +34,9 @@ type CSRConfig struct {
 	// AssetsDir is the directory location where certificates and
 	// private keys will be saved
 	AssetsDir string `json:"assetsDir"`
+
+	// MaxRetry is the maximum attepts to retry client request on failure.
+	MaxRetry int `json:"maxRetry"`
 }
 
 // CertAgent is the top level object that represents a certificate agent.
@@ -99,7 +102,8 @@ func GenerateCSRObject(config CSRConfig) (*capi.CertificateSigningRequest, error
 
 // RequestCertificate will create a certificate signing request for a node
 // with the config given and send it to a signer via a POST request.
-// If something goes wrong it returns an error.
+// If something goes wrong it returns an error unless CSRConfig.MaxRetry
+// is defined in which case we will retry the request.
 // NOTE: This method does not return the approved CSR from the signer.
 func (c *CertAgent) RequestCertificate() error {
 	csr, err := GenerateCSRObject(c.config)
@@ -107,9 +111,28 @@ func (c *CertAgent) RequestCertificate() error {
 		return fmt.Errorf("error generating CSR Object: %v", err)
 	}
 
-	// send CSR to the signer
-	if _, err := c.client.Create(csr); err != nil {
-		return fmt.Errorf("error sending CSR to signer: %v", err)
+	backoff := wait.Backoff{
+		Steps:    c.config.MaxRetry,
+		Duration: 10 * time.Second,
+		Factor:   0.0,
+	}
+
+	var lastErr error
+	// implement a retry mechanism in the case request fails.
+	errc := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		// send CSR to the signer
+		_, err := c.client.Create(csr)
+		if err != nil {
+			lastErr = err
+			return false, nil
+		}
+		return true, nil
+	})
+	if errc != nil {
+		if errc == wait.ErrWaitTimeout && lastErr != nil {
+			errc = lastErr
+		}
+		return fmt.Errorf("error sending CSR to signer: %v", errc)
 	}
 
 	rcvdCSR, err := c.WaitForCertificate()


### PR DESCRIPTION
This PR cherrypicks `--max-retry` functionality added upstream via coreos#25

* `*: add --max-retry flag to kube-client-agent` https://github.com/coreos/kubecsr/pull/25/commits/7732233fdf29a6571e8ae03da91e92a7c62a137a