### PR TITLE
cherry-pick *: add secure and insecure health checks

### DIFF
--- a/cmd/kube-etcd-signer-server/serve.go
+++ b/cmd/kube-etcd-signer-server/serve.go
@@ -31,6 +31,8 @@ var (
 		serverCertDur string
 		metricCertDur string
 		csrDir        string
+
+		insecureHealthCheckAddr string
 	}
 )
 
@@ -43,6 +45,7 @@ func init() {
 	serveCmd.PersistentFlags().StringVar(&serveOpts.mCACrtFile, "metric-cacrt", "", "CA certificate file for metrics signer")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.mCAKeyFile, "metric-cakey", "", "CA private key file for metrics signer")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.addr, "address", "0.0.0.0:6443", "Address on which the signer listens for requests")
+	serveCmd.PersistentFlags().StringVar(&serveOpts.insecureHealthCheckAddr, "insecure-health-check-address", "0.0.0.0:6440", "Address on which the signer listens for insecure health requests")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.metricCertDur, "metriccertdur", "8760h", "Certificate duration for etcd metrics certs (defaults to 365 days)")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.peerCertDur, "peercertdur", "8760h", "Certificate duration for etcd peer certs (defaults to 365 days)")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.serverCertDur, "servercertdur", "8760h", "Certificate duration for etcd server certs (defaults to 365 days)")
@@ -107,6 +110,8 @@ func runCmdServe(cmd *cobra.Command, args []string) error {
 		EtcdPeerCertDuration:   pCertDur,
 		EtcdServerCertDuration: sCertDur,
 		CSRDir:                 serveOpts.csrDir,
+
+		InsecureHealthCheckAddress: serveOpts.insecureHealthCheckAddr,
 	}
 
 	if err := signer.StartSignerServer(c); err != nil {

--- a/pkg/certsigner/signer.go
+++ b/pkg/certsigner/signer.go
@@ -91,6 +91,8 @@ type Config struct {
 	ServerCertKeys []CertKey
 	// ListenAddress is the address at which the server listens for requests
 	ListenAddress string
+	// InsecureHealthCheckAddress is the address at which the server listens for insecure health checks
+	InsecureHealthCheckAddress string
 	// EtcdMetricCertDuration
 	EtcdMetricCertDuration time.Duration
 	// EtcdPeerCertDuration is the cert duration for the `EtcdPeer` profile
@@ -148,6 +150,7 @@ func NewServer(c Config) (*CertServer, error) {
 
 	mux.HandleFunc("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests", server.HandlePostCSR).Methods("POST")
 	mux.HandleFunc("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{csrName}", server.HandleGetCSR).Methods("GET")
+	mux.HandleFunc("/readyz", HandleHealthCheck).Methods("GET", "HEAD")
 
 	return server, nil
 }
@@ -437,6 +440,12 @@ func (s *CertServer) HandleGetCSR(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+// HandleHealthCheck handles health check
+func HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Length", "0")
+	w.WriteHeader(http.StatusOK)
+}
+
 // StartSignerServer initializes a new signer instance.
 func StartSignerServer(c Config) error {
 	s, err := NewServer(c)
@@ -456,6 +465,15 @@ func StartSignerServer(c Config) error {
 		Certificates: certs,
 	}
 	tlsconfig.BuildNameToCertificate()
+
+	// start insecure health check server
+	insecureHCMux := mux.NewRouter()
+	insecureHCMux.HandleFunc("/readyz", HandleHealthCheck).Methods("GET", "HEAD")
+	go (&http.Server{
+		Handler: &loggingHandler{insecureHCMux},
+		Addr:    c.InsecureHealthCheckAddress,
+	}).ListenAndServe()
+
 	return (&http.Server{
 		TLSConfig: tlsconfig,
 		Handler:   h,


### PR DESCRIPTION
cherry-pick from https://github.com/coreos/kubecsr/pull/29

Since the kube-etcd-signer-server mimics the kube-apiserver's CSR apis to sign certs for etcd, it is usually run on the same port as the kube-apiserver.
In those cases serving health checks becomes important as kube-apiserver is usually behind the load-balancers with health checks.

Adds `/readyz` health check to the secure server.
also adds a flag to serve the same health check on an insecure transport as some cloud only support http health checks.