### PR TITLE
Bug 1769985: pkg/certsigner/signer: Add "client" usage to server profile

### DIFF
--- a/pkg/certsigner/signer.go
+++ b/pkg/certsigner/signer.go
@@ -227,6 +227,7 @@ func signerPolicy(c Config) config.Signing {
 				Usage: []string{
 					string(capi.UsageKeyEncipherment),
 					string(capi.UsageDigitalSignature),
+					string(capi.UsageClientAuth),
 					string(capi.UsageServerAuth),
 				},
 				Expiry:       c.EtcdServerCertDuration,


### PR DESCRIPTION
This PR is a cherry-pick of 

* pkg/certsigner/signer: Add "client" usage to server profile … https://github.com/coreos/kubecsr/pull/22

/cc @wking 
