### PR TITLE
Bug 1797133: cherry-pick pkg/certagent: add support for passing escaped IPv6 addresses

### DIFF
--- a/cmd/kube-client-agent/request.go
+++ b/cmd/kube-client-agent/request.go
@@ -67,7 +67,7 @@ func runCmdRequest(cmd *cobra.Command, args []string) error {
 	if requestOpts.ipAddresses != "" {
 		ipAddrs := strings.Split(requestOpts.ipAddresses, ",")
 		for _, addr := range ipAddrs {
-			ip := net.ParseIP(addr)
+			ip := net.ParseIP(agent.UnescapeIPV6Address(addr))
 			if ip == nil {
 				return fmt.Errorf("invalid ipaddress: %s", addr)
 			}

--- a/pkg/certagent/agent.go
+++ b/pkg/certagent/agent.go
@@ -161,3 +161,16 @@ func (c *CertAgent) WaitForCertificate() (req *capi.CertificateSigningRequest, e
 	}
 	return
 }
+
+// UnescapeIPV6Address removes left and right brackets used to escape IPv6 addresses. Example
+// [2605:2700:0:3::4713:93e3] will return 2605:2700:0:3::4713:93e3. If this escaping does
+// not exist return the original address without additional validation.
+func UnescapeIPV6Address(addr string) string {
+	firstChar := addr[:1]
+	lastChar := addr[len(addr)-1:]
+
+	if firstChar == "[" && lastChar == "]" {
+		return addr[1 : len(addr)-1]
+	}
+	return addr
+}

--- a/pkg/certagent/agent_test.go
+++ b/pkg/certagent/agent_test.go
@@ -83,3 +83,23 @@ func TestGenerateCSRObject(t *testing.T) {
 
 	}
 }
+
+func TestUnescapeIPV6Address(t *testing.T) {
+	for _, test := range []struct {
+		ip   string
+		want string
+	}{
+		{"127.0.0.1", "127.0.0.1"},
+		{"127.0.0.1:2379", "127.0.0.1:2379"},
+		{"https://127.0.0.1:2379", "https://127.0.0.1:2379"},
+		{"[::]", "::"},
+		{"[::1]:2379", "[::1]:2379"},
+		{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+		{"https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:2379", "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:2379"},
+	} {
+		got := UnescapeIPV6Address(test.ip)
+		if got != test.want {
+			t.Errorf("UnescapeIPV6Address(%q) = %q want %q", test.ip, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of https://github.com/coreos/kubecsr/pull/31