### PR TITLE
Bug 1878163: Updating ose-kube-client-agent builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.kube-client-agent.rhel
+++ b/Dockerfile.kube-client-agent.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 
 WORKDIR /go/src/github.com/coreos/kubecsr
 
@@ -7,7 +7,7 @@ COPY . .
 RUN make bin/kube-client-agent
 
 # stage 2
-FROM registry.svc.ci.openshift.org/ocp/4.0:base 
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
 
 ENTRYPOINT ["/usr/bin/kube-client-agent"]
 


### PR DESCRIPTION
Updating ose-kube-client-agent builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/990044f295fb1d5e238823902962dbcfa1c041c9/images/ose-kube-client-agent.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
